### PR TITLE
TOPページのプランリストにレビュー数を追加

### DIFF
--- a/app/assets/javascripts/plans.js
+++ b/app/assets/javascripts/plans.js
@@ -308,6 +308,7 @@ $(function() {
 
 $(function() {
   $('.nav-tabs > li > a').tooltip();
+  $('.comment-cont').tooltip();
 });
 
 // return card list from main card list

--- a/app/assets/stylesheets/plans.css.scss
+++ b/app/assets/stylesheets/plans.css.scss
@@ -58,6 +58,10 @@ $bgc-white:           #fefefe;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .comment-cont {
+    font-size: 16px;
+    width: 40px;
+  }
   a {
     width: 100%;
     height: 100%;
@@ -380,6 +384,13 @@ a[href^="#route"]:before {
   font-size: 24px;
 }
 
+.comment-cont:before {
+  font-family: 'Fontello';
+  content: "R";
+  padding: 0 7px 0;
+  font-size: 16px;
+
+}
 .nav-tabs .tooltip {
   width: 100px ;
 }

--- a/app/views/plans/_plans_list.html.haml
+++ b/app/views/plans/_plans_list.html.haml
@@ -9,7 +9,7 @@
           %img{src: 'https://abs.twimg.com/sticky/default_profile_images/default_profile_4_bigger.png', class: 'img-rounded'}/
           .top-screen-name 未登録ユーザ
       %h4= plan[:title]
-      .coment-cont= plan.comments.count
+      .comment-cont{title: 'レビュー数'}= plan.comments.count
       .area-tags
         - (plan[:area_tags] || []).each do |tag|
           %span{ name: tag, class: 'label label-default' }= tag


### PR DESCRIPTION
- レビュー数を追加
- アイコンの適応
- tooltipを使い、アイコンにマウスオーバーすると「レビュー数」が表示される。

![2013-12-10 12 42 27](https://f.cloud.github.com/assets/1221303/1711393/37ba8b3a-614d-11e3-862c-8aed7c9e0e51.png)
