### PR TITLE
TravisCIのテストを動くように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ services:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-- gem install nokogiri -- --with-cflags='--std=gnu99'


### PR DESCRIPTION
## やりたいこと
- TravisCIが落ちているので修正したい

https://travis-ci.org/RyuPiT/SharePla/builds/227367651
```
Fetching: nokogiri-1.7.1.gem (100%)

ERROR:  Error installing nokogiri:
nokogiri requires Ruby version >= 2.1.0.
The command "gem install nokogiri -- --with-cflags='--std=gnu99'" failed and exited with 1 during .
```

## やったこと
- ruby のバージョンが2.1.0以上でないといけないけど、今あげるのは微妙。
- `gem install nokogiri -- --with-cflags='--std=gnu99'` は必要性がないので削除するで対処する
  - そもそもなぜ必要なのかわかってない。
  - https://www.hsbt.org/diary/20120930.html 普通に入れることができなかったのかな。
