### PR TITLE
MongoDBの設定を変更

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -77,7 +77,7 @@ test:
 production:
   sessions:
     default:
-      uri: <%= ENV['MONGOHQ_URL'] %>
+      uri: <%= ENV['MONGODB_URI'] %>
       options:
         consistency: :strong
         max_retries: 1


### PR DESCRIPTION
## やりたいこと
- heroku でエラーが起きているので修正したい。
- mongodb の addon が解除されているので、登録し直す
```
addons@heroku.com: Detach MONGOHQ (@ref:maturing-daily-5796)
7 months ago · v247
```

## やったこと
- [Rails5 on Heroku で MongoDB に接続する](https://qiita.com/rui_jp/items/b9dcbf03fcf362a146a0)を参考にして設定した
- `mLab MongoDB`のAddonを使うように変更