### PR TITLE
Fix deploy from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ deploy:
   app: sharepla
   on:
     repo: RyuPiT/SharePla
+  skip_cleanup: true
 script: "bundle exec rspec"
 services:
 - mongodb


### PR DESCRIPTION
## やりたいこと
- herokuにdeployできるようにしたい
- deployしようとすろと、以下のエラーが出てくる
```
# HEAD detached at 323f7dd
# Untracked files:
# (use "git add <file>..." to include in what will be committed)
#
#	vendor/bundle/
#
nothing added to commit but untracked files present (use "git add" to track)
Dropped refs/stash@{0} (b68ee8945cd7ef1c00d7561ba62048b3340dbe8f)
/home/travis/.rvm/gems/ruby-2.2.5/gems/excon-0.55.0/lib/excon/middlewares/expects.rb:7:in `response_call': Expected([200, 201]) <=> Actual(422 Unprocessable Entity) (Heroku::API::Errors::RequestFailed)
```

## やったこと
- `skip_cleanup: true`を追加してみた